### PR TITLE
Force new line.

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -47,7 +47,7 @@ format: frontpage
         <div class="medium-6 columns">
             {% for post in site.posts limit:1 %}
             {% if post.subheadline %}<p class="subheadline">{{ post.subheadline }}</p>{% endif %}
-            {{post.date | date: "%-d %B %Y"}}
+            {{post.date | date: "%-d %B %Y"}}<br>
             <h4><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h4>
             <p>
                 {% if post.meta_description %}{{ post.meta_description | strip_html | escape }}{% else post.teaser %}{{ post.teaser | strip_html | escape }}{% endif %}


### PR DESCRIPTION
Attempting to force a new line in latest news page to fix this...

<img width="250" height="93" alt="image" src="https://github.com/user-attachments/assets/47bb27af-1f87-436d-80c6-dd1767692ae9" />

In local Jekyll server it looks like this...

<img width="234" height="117" alt="image" src="https://github.com/user-attachments/assets/ed14ccc9-e02a-48e6-897f-c6461a91f05f" />
