### PR TITLE
Starting port to monsoon3 docs

### DIFF
--- a/pages/docs.md
+++ b/pages/docs.md
@@ -16,7 +16,9 @@ header:
 
 * #### [PUMA2]({{ 'puma2' | relative_url }})
 
-* #### [Monsoon2]({{ 'monsoon2' | relative_url }})
+* #### [Monsoon2]({{ 'monsoon2' | relative_url }}) ➡️  Note this has now been superseded by Monsoon3.
+
+* #### [Monsoon3]({{ 'monsoon3' | relative_url }})
 
 * #### [Rose/Cylc]({{ 'rose-cylc' | relative_url }})
 

--- a/pages/monsoon3.md
+++ b/pages/monsoon3.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: Monsoon3
+subheadline: Met Office/NERC Collaboration HPC
+teaser: 
+permalink: /monsoon3/
+image:
+   title: monsoon.jpeg
+---
+
+### Introduction to the Monsoon service
+
+Monsoon3 is the third iteration of the collaborative HPC hosted at the Met Office in Exeter and is a key piece of underpinning infrastructure for the strategic partnership between the Met Office and NERC. It aims to improve collaboration between scientists funded by the two organisations by facilitating:
+
+* Sharing of modelling results
+* Joint development of software
+* Access to Met Office data
+
+The Monsoon service currently consists of:
+
+* 130 nodes
+* 256 GiB of memory per node
+* 2 CPUs per node (AMD Milan)
+
+Monsoon3's architecture consists of:
+
+* x86 architecture
+* NUMA configuration
+* Zen 3 instruction set
+* 8 chiplets per CPU
+* Each chiplet has 8 cores
+* Each chiplet shares an L3 cache
+
+More detailed technical specifications can be found [here](https://code.metoffice.gov.uk/doc/monsoon3/tech_specs.html). 
+
+
+### Help and Support
+
+For help and support on the Monsoon service users should contact:
+
+* Monsoon support (monsoon AT metoffice.gov.uk) for all questions about service delivery, login issues, and current or potential collaborative project proposals.
+* [CMS Helpdesk](https://cms-helpdesk.ncas.ac.uk) for all questions relating to running the UM on Monsoon.
+* Further information can also be found in the [Monsoon User Guide](https://code.metoffice.gov.uk/doc/monsoon3/index.html) available on [MOSRS](https://code.metoffice.gov.uk)


### PR DESCRIPTION
Monsoon2 docs are heavily embedded so will need some careful through about how to future-proof the Monsoon docs in general as part of a process of overall simplification/generalisation throughout the site.